### PR TITLE
dpkg check results in error and glib 2.0 libraries are not installed

### DIFF
--- a/ubuntu-20.04-change-gdm-background
+++ b/ubuntu-20.04-change-gdm-background
@@ -11,8 +11,7 @@ if [ "$(id -u)" -ne 0 ] ; then
 fi
 
 # Check if glib 2.0 development libraries are installed.
-if [ ! $(dpkg -s libglib2.0-dev-bin | grep Status | cut -d ' ' -f 4) \
-    == installed ]; then
+if ! [ -x "$(command -v glib-compile-resources)" ]; then
     echo 'Additional glib 2.0 libraries need to be installed.'
     read -p 'Type y or Y to proceed. Any other key to exit: ' -n 1
     if [[ "$REPLY" =~ ^[yY]$ ]]; then


### PR DESCRIPTION

Hi I've got a quick fix, please have a look.

Current problem: The `dpkg -s` check near the beginning of the script results in an error, and the script does not ask to install the glib 2.0 libraries: 

![image](https://user-images.githubusercontent.com/746276/81982036-0fbb9a80-9629-11ea-96e4-f89d874ad4dd.png)

> dpkg-query: package 'libglib2.0-dev-bin' is not installed and no information is available
Use dpkg --info (= dpkg-deb --info) to examine archive files.
./ubuntu-20.04-change-gdm-background: line 93: glib-compile-resources: command not found
mv: cannot stat 'gdm3-theme.gresource': No such file or directory
something went wrong.
GDM background sucessfully restored.
Restart GDM service to apply change.

In this PR I'm using `command -v` to check if the `glib-compile-resources` is installed.  With this change, I get the prompt to install:

![image](https://user-images.githubusercontent.com/746276/81982342-96707780-9629-11ea-9f98-ad5bfa8626d4.png)
