### PR TITLE
Root 'check/warn' change to 'ask'.

### DIFF
--- a/ubuntu-20.04-change-gdm-background
+++ b/ubuntu-20.04-change-gdm-background
@@ -7,7 +7,7 @@
 # Check if this script is run by root and execute it with sudo if it is not.
 if [ "$UID" -ne 0 ]; then
     exec sudo "$0" "$@"
-	exit
+    exit
 fi
 
 if [ ! "$(lsb_release -c | cut -f 2)" == focal ]; then

--- a/ubuntu-20.04-change-gdm-background
+++ b/ubuntu-20.04-change-gdm-background
@@ -4,10 +4,10 @@
 # URL: https://github.com/thiggy01/ubuntu-20.04-change-gdm-background
 # =================================================================== #
 
-# Check if script is run by root.
-if [ "$(id -u)" -ne 0 ] ; then
-    echo 'This script must be run as root.'
-    exit 1
+# Check if this script is run by root and execute it with sudo if it is not.
+if [ "$UID" -ne 0 ]; then
+    exec sudo "$0" "$@"
+	exit
 fi
 
 if [ ! "$(lsb_release -c | cut -f 2)" == focal ]; then

--- a/ubuntu-20.04-change-gdm-background
+++ b/ubuntu-20.04-change-gdm-background
@@ -5,7 +5,7 @@
 # =================================================================== #
 
 # Check if this script is run by root and execute it with sudo if it is not.
-if [ "$UID" -ne 0 ]; then
+if [ "$(id -u)" -ne 0 ]; then
     exec sudo "$0" "$@"
     exit
 fi


### PR DESCRIPTION
Instead of warning that the script is not ran as `sudo` I recommend skipping the warning and just asking for `sudo`.

For those who worry about it being a security issue; If a persons `sudo` is not configured correctly then they have far bigger issues to worry about anyway.