### PR TITLE
Adding support for Ubuntu 22.04 Jammy

### DIFF
--- a/change-gdm-background
+++ b/change-gdm-background
@@ -124,7 +124,7 @@ CleanUp() {
 
 ReplacingBg() {
     oldBg="#lockDialogGroup \{\n?.*?\}"
-    if  [[ "$distro" == "impish" ]]; then
+    if  [[ "$distro" =~ (impish|jammy) ]]; then
         perl -i -0777 -pe "s/$oldBg/$newBg/s" "$workDir"/theme/gdm.css
     else 
         perl -i -0777 -pe "s/$oldBg/$newBg/s" "$workDir"/theme/gdm3.css

--- a/change-gdm-background
+++ b/change-gdm-background
@@ -12,8 +12,8 @@ fi
 
 # Check what linux distro is being used.
 distro="$(lsb_release -c | cut -f 2)"
-if ! [[ "$distro" =~ (focal|groovy|hirsute|impish) ]]; then
-    echo 'Sorry, this script only works with focal, groovy or hirsute distros.'
+if ! [[ "$distro" =~ (focal|groovy|hirsute|impish|jammy) ]]; then
+    echo 'Sorry, this script only works with focal, groovy, hirsute, impish or jammy distros.'
     exit 1
 fi
 


### PR DESCRIPTION
Hello again.  Just like Impish, in Jammy (Ubuntu 22.04)  the wallpaper is being set in `gdm.css` instead of `gdm3.css`. 

Fixes #31 and also includes the text 'impish' for @duckimann peace of mind: https://github.com/thiggy01/change-gdm-background/pull/29#issuecomment-962546848 

I tested this in a VM using the [daily build image](https://cdimage.ubuntu.com/daily-live/current/).  

![VirtualBox_Ubuntu2204_14_11_2021_21_38_54](https://user-images.githubusercontent.com/746276/141699789-10139908-fa69-47f6-affd-15c46f3dcc2d.png)

![VirtualBox_Ubuntu2204_14_11_2021_21_39_04](https://user-images.githubusercontent.com/746276/141699791-13048cfb-ef01-487c-af13-9662e51bbdc9.png)

